### PR TITLE
Storage changes

### DIFF
--- a/src/config/config.interface.ts
+++ b/src/config/config.interface.ts
@@ -4,6 +4,7 @@ export interface WebStorageConfigInterface {
     clearType?: ClearType;
     mutateObjects?: boolean;
     cookiesScope?: string;
+    cookiesCheckInterval?: number;
     debugMode?: boolean;
 }
 export type ClearType = 'decorators' | 'prefix' | 'all';

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -12,6 +12,7 @@ const DefaultConfig: WebStorageConfigInterface = {
     clearType: 'prefix',
     mutateObjects: true,
     cookiesScope: '',
+    cookiesCheckInterval: 0,
     debugMode: false,
 };
 

--- a/src/service/cookies-storage.service.ts
+++ b/src/service/cookies-storage.service.ts
@@ -1,3 +1,4 @@
+import { cookiesStorage } from '../utility/storage/cookies-storage';
 import { WebStorageService } from './webstorage.service';
 import { cookiesStorageUtility } from '../utility/index';
 import { Injectable } from '@angular/core';
@@ -8,6 +9,7 @@ export class CookiesStorageService extends WebStorageService {
 
     constructor() {
         super(cookiesStorageUtility);
+        this._changes = cookiesStorage.changes.asObservable();
     }
 
     public set(key: string, value: any, expirationDate?: Date): any {

--- a/src/service/local-storage.service.ts
+++ b/src/service/local-storage.service.ts
@@ -3,14 +3,33 @@ import { localStorageUtility } from '../utility/index';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Rx';
 import { NgxStorageEvent } from '../utility/storage/storage-event';
+import { Subject } from 'rxjs/Subject';
+import { ClearType } from '../config/config.interface';
 
 @Injectable()
 export class LocalStorageService extends WebStorageService {
     public static keys: Array<string> = [];
+    protected internalChanges: Subject<NgxStorageEvent> = new Subject();
 
     constructor() {
         super(localStorageUtility);
         this._changes = Observable.fromEvent(window, 'storage')
-            .filter((event: NgxStorageEvent) => event.storageArea === localStorage);
+            .filter((event: NgxStorageEvent) => event.storageArea === localStorage)
+            .merge(this.internalChanges);
+    }
+
+    public set(key: string, value: any): void {
+        this.internalChanges.next(this.generateEvent(key, value));
+        return super.set(key, value);
+    }
+
+    public clear(clearType?: ClearType, secondParam?: any): void {
+        this.internalChanges.next(this.generateEvent(null, null));
+        return super.clear(clearType, secondParam);
+    }
+
+    public remove(key: string): void {
+        this.internalChanges.next(this.generateEvent(key, null));
+        return super.remove(key);
     }
 }

--- a/src/service/local-storage.service.ts
+++ b/src/service/local-storage.service.ts
@@ -1,6 +1,7 @@
 import { WebStorageService } from './webstorage.service';
 import { localStorageUtility } from '../utility/index';
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Rx';
 
 @Injectable()
 export class LocalStorageService extends WebStorageService {
@@ -8,5 +9,7 @@ export class LocalStorageService extends WebStorageService {
 
     constructor() {
         super(localStorageUtility);
+        this._changes = Observable.fromEvent(window, 'storage')
+            .filter((event: StorageEvent) => event.storageArea === localStorage);
     }
 }

--- a/src/service/local-storage.service.ts
+++ b/src/service/local-storage.service.ts
@@ -2,6 +2,7 @@ import { WebStorageService } from './webstorage.service';
 import { localStorageUtility } from '../utility/index';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Rx';
+import { NgxStorageEvent } from '../utility/storage/storage-event';
 
 @Injectable()
 export class LocalStorageService extends WebStorageService {
@@ -10,6 +11,6 @@ export class LocalStorageService extends WebStorageService {
     constructor() {
         super(localStorageUtility);
         this._changes = Observable.fromEvent(window, 'storage')
-            .filter((event: StorageEvent) => event.storageArea === localStorage);
+            .filter((event: NgxStorageEvent) => event.storageArea === localStorage);
     }
 }

--- a/src/service/session-storage.service.ts
+++ b/src/service/session-storage.service.ts
@@ -1,6 +1,7 @@
 import { WebStorageService } from './webstorage.service';
 import { sessionStorageUtility } from '../utility/index';
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Rx';
 
 @Injectable()
 export class SessionStorageService extends WebStorageService {
@@ -8,5 +9,7 @@ export class SessionStorageService extends WebStorageService {
 
     constructor() {
         super(sessionStorageUtility);
+        this._changes = Observable.fromEvent(window, 'storage')
+            .filter((event: StorageEvent) => event.storageArea === sessionStorage);
     }
 }

--- a/src/service/session-storage.service.ts
+++ b/src/service/session-storage.service.ts
@@ -3,14 +3,33 @@ import { sessionStorageUtility } from '../utility/index';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Rx';
 import { NgxStorageEvent } from '../utility/storage/storage-event';
+import { ClearType } from '../config/config.interface';
+import { Subject } from 'rxjs/Subject';
 
 @Injectable()
 export class SessionStorageService extends WebStorageService {
     public static keys: Array<string> = [];
+    protected internalChanges: Subject<NgxStorageEvent> = new Subject();
 
     constructor() {
         super(sessionStorageUtility);
         this._changes = Observable.fromEvent(window, 'storage')
-            .filter((event: NgxStorageEvent) => event.storageArea === sessionStorage);
+            .filter((event: NgxStorageEvent) => event.storageArea === sessionStorage)
+            .merge(this.internalChanges);
+    }
+
+    public set(key: string, value: any): void {
+        this.internalChanges.next(this.generateEvent(key, value));
+        return super.set(key, value);
+    }
+
+    public clear(clearType?: ClearType, secondParam?: any): void {
+        this.internalChanges.next(this.generateEvent(null, null));
+        return super.clear(clearType, secondParam);
+    }
+
+    public remove(key: string): void {
+        this.internalChanges.next(this.generateEvent(key, null));
+        return super.remove(key);
     }
 }

--- a/src/service/session-storage.service.ts
+++ b/src/service/session-storage.service.ts
@@ -2,6 +2,7 @@ import { WebStorageService } from './webstorage.service';
 import { sessionStorageUtility } from '../utility/index';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Rx';
+import { NgxStorageEvent } from '../utility/storage/storage-event';
 
 @Injectable()
 export class SessionStorageService extends WebStorageService {
@@ -10,6 +11,6 @@ export class SessionStorageService extends WebStorageService {
     constructor() {
         super(sessionStorageUtility);
         this._changes = Observable.fromEvent(window, 'storage')
-            .filter((event: StorageEvent) => event.storageArea === sessionStorage);
+            .filter((event: NgxStorageEvent) => event.storageArea === sessionStorage);
     }
 }

--- a/src/service/shared-storage.service.ts
+++ b/src/service/shared-storage.service.ts
@@ -1,6 +1,7 @@
 import { WebStorageService } from './webstorage.service';
 import { sharedStorageUtility } from '../utility/index';
 import { Injectable } from '@angular/core';
+import { sharedStorage } from '../utility/storage/shared-storage';
 
 @Injectable()
 export class SharedStorageService extends WebStorageService {
@@ -8,5 +9,6 @@ export class SharedStorageService extends WebStorageService {
 
     constructor() {
         super(sharedStorageUtility);
+        this._changes = sharedStorage.changes.asObservable();
     }
 }

--- a/src/service/webstorage.service.ts
+++ b/src/service/webstorage.service.ts
@@ -49,6 +49,9 @@ export abstract class WebStorageService {
         return this._changes.filter((event: NgxStorageEvent) => {
             if (!key) { return true; }
             if (exactMatch) {
+                if (key.startsWith(Config.prefix)) {
+                    return event.key === key;
+                }
                 return event.key === Config.prefix + key;
             } else {
                 return event.key.indexOf(key) !== -1;

--- a/src/service/webstorage.service.ts
+++ b/src/service/webstorage.service.ts
@@ -56,7 +56,7 @@ export abstract class WebStorageService {
             } else {
                 return event.key.indexOf(key) !== -1;
             }
-        });
+        }).delay(30); // event should come after actual data change and propagation
     }
 
     /**

--- a/src/service/webstorage.service.ts
+++ b/src/service/webstorage.service.ts
@@ -6,10 +6,11 @@ import { debug } from '../config/config';
 import { Cache } from '../decorator/cache';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/filter';
+import { NgxStorageEvent } from '../utility/storage/storage-event';
 
 export abstract class WebStorageService {
     public static keys: Array<string>;
-    protected _changes: Observable<StorageEvent>;
+    protected _changes: Observable<NgxStorageEvent>;
 
     public constructor(public utility: WebStorageUtility) { }
 
@@ -45,7 +46,7 @@ export abstract class WebStorageService {
     }
 
     public observe(key?: string, exactMatch?: boolean) {
-        return this._changes.filter((event: StorageEvent) => {
+        return this._changes.filter((event: NgxStorageEvent) => {
             if (!key) { return true; }
             if (exactMatch) {
                 return event.key === Config.prefix + key;

--- a/src/service/webstorage.service.ts
+++ b/src/service/webstorage.service.ts
@@ -61,22 +61,10 @@ export abstract class WebStorageService {
 
     /**
      * Clears chosen data from Storage
-     * @param clearType 'prefix'
-     * @param prefix defines the prefix
+     * @param clearType 'prefix' | 'decorators' | 'all'
+     * @param secondParam defines the prefix or class (not its instance) whose decorators should be cleared
      */
-    public clear(clearType?: 'prefix', prefix?: string): void;
-    /**
-     * Clears chosen data from Storage
-     * @param clearType 'decorators'
-     * @param target defines the class (not its instance) whose decorators should be cleared
-     */
-    public clear(clearType?: 'decorators', target?: Object): void;
-    /**
-     * Clears all data from Storage
-     * @param clearType 'all'
-     */
-    public clear(clearType?: 'all'): void;
-    public clear(clearType?: ClearType, secondParam?: any): void {
+    public clear(clearType?: ClearType, secondParam?: string | object): void {
         clearType = clearType || Config.clearType;
         if (clearType === 'decorators') {
             let keys = [];
@@ -91,7 +79,7 @@ export abstract class WebStorageService {
         } else if (clearType === 'prefix') {
             secondParam = secondParam || Config.prefix;
             this.utility.forEach((value, key) => {
-                if (key.startsWith(secondParam)) {
+                if (key.startsWith(<string>secondParam)) {
                     this.remove(this.utility.trimPrefix(key));
                 }
             });

--- a/src/service/webstorage.service.ts
+++ b/src/service/webstorage.service.ts
@@ -4,9 +4,12 @@ import { WebStorageUtility } from '../utility/webstorage-utility';
 import { WebStorageServiceInterface } from './webstorage.interface';
 import { debug } from '../config/config';
 import { Cache } from '../decorator/cache';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/filter';
 
 export abstract class WebStorageService {
     public static keys: Array<string>;
+    protected _changes: Observable<StorageEvent>;
 
     public constructor(public utility: WebStorageUtility) { }
 
@@ -39,6 +42,17 @@ export abstract class WebStorageService {
     // TODO return true if item existed and false otherwise (?)
     public remove(key: string): void {
         return this.utility.remove(key);
+    }
+
+    public observe(key?: string, exactMatch?: boolean) {
+        return this._changes.filter((event: StorageEvent) => {
+            if (!key) { return true; }
+            if (exactMatch) {
+                return event.key === Config.prefix + key;
+            } else {
+                return event.key.indexOf(key) !== -1;
+            }
+        });
     }
 
     /**

--- a/src/service/webstorage.service.ts
+++ b/src/service/webstorage.service.ts
@@ -99,4 +99,12 @@ export abstract class WebStorageService {
             this.utility.clear();
         }
     }
+
+    protected generateEvent(key: string, newValue: any, oldValue?: any): NgxStorageEvent {
+        let type = this.utility.getStorageName().charAt(0).toLowerCase() + this.utility.getStorageName().slice(1);
+        let event = new NgxStorageEvent(type, key, this.utility.getStorage());
+        event.oldValue = (oldValue !== undefined) ? oldValue : this.get(key);
+        event.newValue = newValue;
+        return event;
+    }
 }

--- a/src/utility/storage/cookies-storage.ts
+++ b/src/utility/storage/cookies-storage.ts
@@ -64,8 +64,8 @@ export class CookiesStorage extends NgxStorage {
         } else if (expirationDate === null) {
             utcDate = 'Fri, 18 Dec 2099 12:00:00 GMT';
         }
-        let expires = utcDate ? '; expires=' + utcDate + ';' : '';
-        let cookie = key + '=' + data + expires + 'path=/;' + domain;
+        let expires = utcDate ? '; expires=' + utcDate : '';
+        let cookie = key + '=' + value + expires + ';path=/;' + domain;
         debug.log('Cookie`s set instruction:', cookie);
         this.emitEvent(key, WebStorageUtility.getGettable(data));
         document.cookie = cookie;

--- a/src/utility/storage/cookies-storage.ts
+++ b/src/utility/storage/cookies-storage.ts
@@ -68,7 +68,7 @@ export class CookiesStorage extends NgxStorage {
         let expires = utcDate ? '; expires=' + utcDate : '';
         let cookie = key + '=' + value + expires + ';path=/;' + domain;
         debug.log('Cookie`s set instruction:', cookie);
-        this.emitEvent(key, WebStorageUtility.getGettable(value));
+        this.emitEvent(key, WebStorageUtility.getGettable(value), WebStorageUtility.getGettable(this.cachedItemsMap.get(key)));
         this.cachedItemsMap.set(key, value);
         document.cookie = cookie;
     }

--- a/src/utility/storage/cookies-storage.ts
+++ b/src/utility/storage/cookies-storage.ts
@@ -105,12 +105,17 @@ export class CookiesStorage extends NgxStorage {
             let cachedValue = this.cachedItemsMap.get(key);
             cachedValue = (cachedValue !== undefined) ? cachedValue : null;
             if (value !== cachedValue) {
-                this.emitEvent(key, WebStorageUtility.getGettable(value), WebStorageUtility.getGettable(cachedValue));
+                this.emitEvent(
+                    key,
+                    WebStorageUtility.getGettable(value),
+                    WebStorageUtility.getGettable(cachedValue),
+                    false,
+                );
             }
         });
         this.cachedItemsMap.forEach((value, key) => {
             if (!map.has(key)) {
-                this.emitEvent(key, null, WebStorageUtility.getGettable(value));
+                this.emitEvent(key, null, WebStorageUtility.getGettable(value), false);
             }
         });
         this.cachedCookieString = document.cookie;

--- a/src/utility/storage/shared-storage.ts
+++ b/src/utility/storage/shared-storage.ts
@@ -12,7 +12,8 @@ export class SharedStorage implements Storage {
     }
 
     public getItem(key: string): any {
-        return this.sharedMap.get(key);
+        let value = this.sharedMap.get(key);
+        return (value !== undefined) ? value : null;
     }
 
     public removeItem(key: string): void {

--- a/src/utility/storage/shared-storage.ts
+++ b/src/utility/storage/shared-storage.ts
@@ -1,6 +1,6 @@
-export class SharedStorage implements Storage {
-    [key: string]: any;
-    [index: number]: string;
+import { NgxStorage } from './storage';
+
+export class SharedStorage extends NgxStorage {
     protected sharedMap: Map<string, any> = new Map();
 
     public get length(): number {
@@ -17,14 +17,17 @@ export class SharedStorage implements Storage {
     }
 
     public removeItem(key: string): void {
+        this.emitEvent(key, null);
         this.sharedMap.delete(key);
     }
 
-    public setItem(key: string, data: any): void {
-        this.sharedMap.set(key, data);
+    public setItem(key: string, value: any): void {
+        this.emitEvent(key, value);
+        this.sharedMap.set(key, value);
     }
 
     public clear(): void {
+        this.emitEvent(null, null);
         this.sharedMap.clear();
     }
 

--- a/src/utility/storage/shared-storage.ts
+++ b/src/utility/storage/shared-storage.ts
@@ -3,6 +3,10 @@ import { NgxStorage } from './storage';
 export class SharedStorage extends NgxStorage {
     protected sharedMap: Map<string, any> = new Map();
 
+    protected get type() {
+        return 'sharedStorage';
+    }
+
     public get length(): number {
         return this.getAllKeys().length;
     }

--- a/src/utility/storage/storage-event.ts
+++ b/src/utility/storage/storage-event.ts
@@ -1,4 +1,4 @@
-export class NgxStorageEvent {
+export class NgxStorageEvent implements StorageEvent {
     protected static initTimeStamp = Date.now();
     public oldValue?: any;
     public newValue: any;
@@ -13,12 +13,52 @@ export class NgxStorageEvent {
     public readonly isTrusted = true;
     public readonly path = [window];
     public readonly returnValue = true;
-    public readonly srcElement = window;
+    public readonly srcElement = <any>window;
     public readonly target = window;
     public readonly url = window.location.href;
     public readonly isInternal = true;
 
     constructor(public type: string, public key: string, public storageArea: Storage) {
-        Object.setPrototypeOf(this, StorageEvent);
+        setTimeout(() => Object.setPrototypeOf(this, new StorageEvent(type)));
+    }
+
+    /**
+     * Methods below exist only to satisfy TypeScript compiler
+     */
+
+    public get scoped() {
+        return undefined;
+    };
+
+    public get initEvent() {
+        return undefined;
+    };
+
+    public get preventDefault() {
+        return undefined;
+    }
+
+    public get stopImmediatePropagation() {
+        return undefined;
+    }
+
+    public get stopPropagation() {
+        return undefined;
+    }
+
+    public get deepPath() {
+        return undefined;
+    }
+
+    public get AT_TARGET() {
+        return undefined;
+    }
+
+    public get BUBBLING_PHASE() {
+        return undefined;
+    }
+
+    public get CAPTURING_PHASE() {
+        return undefined;
     }
 }

--- a/src/utility/storage/storage-event.ts
+++ b/src/utility/storage/storage-event.ts
@@ -16,7 +16,7 @@ export class NgxStorageEvent implements StorageEvent {
     public readonly srcElement = <any>window;
     public readonly target = window;
     public readonly url = window.location.href;
-    public readonly isInternal = true;
+    public isInternal = true;
 
     constructor(public type: string, public key: string, public storageArea: Storage) {
         setTimeout(() => Object.setPrototypeOf(this, new StorageEvent(type)));

--- a/src/utility/storage/storage-event.ts
+++ b/src/utility/storage/storage-event.ts
@@ -9,13 +9,14 @@ export class NgxStorageEvent {
     public readonly composed = false;
     public readonly currentTarget = window;
     public readonly defaultPrevented = false;
-    public readonly evenPhase = 2;
+    public readonly eventPhase = 2;
     public readonly isTrusted = true;
     public readonly path = [window];
     public readonly returnValue = true;
     public readonly srcElement = window;
     public readonly target = window;
     public readonly url = window.location.href;
+    public readonly isInternal = true;
 
     constructor(public type: string, public key: string, public storageArea: Storage) {
         Object.setPrototypeOf(this, StorageEvent);

--- a/src/utility/storage/storage-event.ts
+++ b/src/utility/storage/storage-event.ts
@@ -1,0 +1,23 @@
+export class NgxStorageEvent {
+    protected static initTimeStamp = Date.now();
+    public oldValue?: any;
+    public newValue: any;
+    public timeStamp = (Date.now() - NgxStorageEvent.initTimeStamp);
+    public readonly bubbles = false;
+    public readonly cancelBubble = false;
+    public readonly cancelable = false;
+    public readonly composed = false;
+    public readonly currentTarget = window;
+    public readonly defaultPrevented = false;
+    public readonly evenPhase = 2;
+    public readonly isTrusted = true;
+    public readonly path = [window];
+    public readonly returnValue = true;
+    public readonly srcElement = window;
+    public readonly target = window;
+    public readonly url = window.location.href;
+
+    constructor(public type: string, public key: string, public storageArea: Storage) {
+        Object.setPrototypeOf(this, StorageEvent);
+    }
+}

--- a/src/utility/storage/storage.ts
+++ b/src/utility/storage/storage.ts
@@ -1,0 +1,21 @@
+import { NgxStorageEvent } from './storage-event';
+import { Subject } from 'rxjs/Subject';
+
+export abstract class NgxStorage implements Storage {
+    [key: string]: any;
+    [index: number]: string;
+    public changes: Subject<NgxStorageEvent> = new Subject();
+    public abstract getItem(key: string): any;
+    public abstract setItem(key: string, value: any): void;
+    public abstract removeItem(key: string): void;
+    public abstract clear(): void;
+    public abstract get length();
+    public abstract key(index: number);
+
+    protected emitEvent(key: string, newValue: any) {
+        let event = new NgxStorageEvent('sharedStorage', key, this);
+        event.oldValue = this.getItem(key);
+        event.newValue = newValue;
+        this.changes.next(event);
+    }
+}

--- a/src/utility/storage/storage.ts
+++ b/src/utility/storage/storage.ts
@@ -15,9 +15,9 @@ export abstract class NgxStorage implements Storage {
 
     protected abstract get type(): string;
 
-    protected emitEvent(key: string, newValue: any) {
+    protected emitEvent(key: string, newValue: any, oldValue?: any) {
         let event = new NgxStorageEvent(this.type, key, this);
-        event.oldValue = this.getItem(key);
+        event.oldValue = (oldValue !== undefined) ? oldValue : this.getItem(key);
         event.newValue = newValue;
         this.changes.next(event);
     }

--- a/src/utility/storage/storage.ts
+++ b/src/utility/storage/storage.ts
@@ -15,10 +15,12 @@ export abstract class NgxStorage implements Storage {
 
     protected abstract get type(): string;
 
-    protected emitEvent(key: string, newValue: any, oldValue?: any) {
+    // TODO consider passing parameters in object
+    protected emitEvent(key: string, newValue: any, oldValue?: any, isInternal: boolean = true) {
         let event = new NgxStorageEvent(this.type, key, this);
         event.oldValue = (oldValue !== undefined) ? oldValue : this.getItem(key);
         event.newValue = newValue;
+        event.isInternal = isInternal;
         this.changes.next(event);
     }
 }

--- a/src/utility/storage/storage.ts
+++ b/src/utility/storage/storage.ts
@@ -1,19 +1,22 @@
 import { NgxStorageEvent } from './storage-event';
 import { Subject } from 'rxjs/Subject';
 
+// TODO: in the future use ES6 Proxy to handle indexers
 export abstract class NgxStorage implements Storage {
     [key: string]: any;
     [index: number]: string;
     public changes: Subject<NgxStorageEvent> = new Subject();
-    public abstract getItem(key: string): any;
     public abstract setItem(key: string, value: any): void;
     public abstract removeItem(key: string): void;
+    public abstract getItem(key: string): any;
+    public abstract key(index: number);
     public abstract clear(): void;
     public abstract get length();
-    public abstract key(index: number);
+
+    protected abstract get type(): string;
 
     protected emitEvent(key: string, newValue: any) {
-        let event = new NgxStorageEvent('sharedStorage', key, this);
+        let event = new NgxStorageEvent(this.type, key, this);
         event.oldValue = this.getItem(key);
         event.newValue = newValue;
         this.changes.next(event);

--- a/src/utility/webstorage-utility.ts
+++ b/src/utility/webstorage-utility.ts
@@ -53,6 +53,10 @@ export class WebStorageUtility {
         return keys;
     }
 
+    public getStorage() {
+        return this._storage;
+    }
+
     public getStorageKey(key: string, prefix?: string): string {
         prefix = (typeof prefix === 'string') ? prefix : this._prefix;
         return `${prefix}${key}`;

--- a/src/utility/webstorage-utility.ts
+++ b/src/utility/webstorage-utility.ts
@@ -2,7 +2,7 @@ import { DecoratorConfig } from '../decorator/webstorage';
 import { WebStorage } from './storage/cookies-storage';
 import { Cache } from '../decorator/cache';
 import { debug } from '../config/config';
-export type StorageName = 'LocalStorage' | 'SessionStorage' | 'CookiesStorage';
+export type StorageName = 'LocalStorage' | 'SessionStorage' | 'CookiesStorage' | 'SharedStorage';
 
 export class WebStorageUtility {
     protected _prefix: string = '';


### PR DESCRIPTION
This PR adds `WebstorageService.observe()` method (what means it's available for Session-, Local-, Shared- and CookiesStorageService). The mentioned method can take 2 parameters:
```
public observe(key?: string, exactMatch?: boolean);
```
`key` specifies filter pattern for `event.key`, by default it's enough to just contain it, but we can easily change the behaviour by passing `exactMatch = true` - in this case prefix is automatically added to the passed key if not included. Returned value is an RxJS Observable of `NgxStorageEvent`, which is just a wrap for native [`StorageEvent`](https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent) with added `isInternal = true` property, so we can filter out e.g. localStorage events from other tab by this code:
```
this.localStorageService.observe()
  .filter(event => !event.isInternal)
  .subscribe((event) => {
    // events here are equal like would be in:
    // window.addEventListener('storage', (event) => {});
    // excluding SessionStorage events
  });
```
In order to listen for changes in cookies constantly (i.e. if they can get changed by server or external library), we have to specify `Config.cookiesCheckInterval`.  I recommend setting it to 1000 ms as it's fast enough in most of cases and doesn't cause noticeably CPU usage. These changes are being detected only if there is active subscription to `CookiesStorageService.observer()`.

Available via: `npm install ngx-store@beta`