### PR TITLE
Change to storage-event.ts for compatibility with Angular 5

### DIFF
--- a/src/utility/storage/storage-event.ts
+++ b/src/utility/storage/storage-event.ts
@@ -1,7 +1,8 @@
 export class NgxStorageEvent implements StorageEvent {
     protected static initTimeStamp = Date.now();
-    public oldValue?: any;
+    public oldValue: any;
     public newValue: any;
+    public NONE: any;
     public timeStamp = (Date.now() - NgxStorageEvent.initTimeStamp);
     public readonly bubbles = false;
     public readonly cancelBubble = false;


### PR DESCRIPTION
Change to storage-event.ts for compatibility with Angular 5

```
ERROR in node_modules/ngx-store/src/utility/storage/storage-event.d.ts(1,22): error TS2420: Class 'NgxStorageEvent' incorrectly implements interface 'StorageEvent'.
  Property 'NONE' is missing in type 'NgxStorageEvent'.
```

```
ERROR in node_modules/ngx-store/src/utility/storage/storage-event.d.ts(1,22): error TS2420: Class 'NgxStorageEvent' incorrectly implements interface 'StorageEvent'.
  Property 'oldValue' is optional in type 'NgxStorageEvent' but required in type 'StorageEvent'.
```