### PR TITLE
fix(WebStorageService): don't filter keys by prefix if it is empty

### DIFF
--- a/src/service/webstorage.service.ts
+++ b/src/service/webstorage.service.ts
@@ -21,10 +21,10 @@ export abstract class WebStorageService {
     public get keys(): Array<string> {
         // get prefixed key if prefix is defined
         const prefixKeys = this.utility.keys.filter(key => {
-            if(this.utility.prefix && this.utility.prefix.length) {
+            if (this.utility.prefix && this.utility.prefix.length) {
                 return key.startsWith(this.utility.prefix);
             }
-            return true
+            return true;
         });
         const decoratorKeys = (<WebStorageServiceInterface>this.constructor).keys;
         return prefixKeys.concat(decoratorKeys);

--- a/src/service/webstorage.service.ts
+++ b/src/service/webstorage.service.ts
@@ -21,7 +21,10 @@ export abstract class WebStorageService {
     public get keys(): Array<string> {
         // get prefixed key if prefix is defined
         const prefixKeys = this.utility.keys.filter(key => {
-            return this.utility.prefix && key.startsWith(this.utility.prefix);
+            if(this.utility.prefix && this.utility.prefix.length) {
+                return key.startsWith(this.utility.prefix);
+            }
+            return true
         });
         const decoratorKeys = (<WebStorageServiceInterface>this.constructor).keys;
         return prefixKeys.concat(decoratorKeys);


### PR DESCRIPTION
if prefix is an empty string, it will not return any keys, but it should actually return all keys

as the docs mention, that the prefix can be set to an empty string, the method here should return all keys. however, it returns no keys at all. The prefix should only be evaluated if it is set and has a length (so not being an empty string)